### PR TITLE
Fix battery time display logic and output power comparison

### DIFF
--- a/index.html
+++ b/index.html
@@ -2530,10 +2530,14 @@ Example format:
                     document.getElementById('remainingKwh').textContent = totalKwh.toFixed(2);
 
                     // Time display: Show "Time to Full" when charging, "Time to Empty" when discharging
-                    const isCharging = (inputTotal > 0 || inputRatified > 0 || inputDC > 0) && (inputTotal > output || (inputRatified + inputDC) > output);
+                    // Use Reg 20 (totalWatts) for output comparison - Reg 39 is undocumented
+                    const isCharging = (inputTotal > 0 || inputRatified > 0 || inputDC > 0) && (inputTotal > totalWatts || (inputRatified + inputDC) > totalWatts);
                     const displayMinutes = isCharging ? timeToFull : timeToEmpty;
                     const timeLabel = isCharging ? '⚡' : '🔋'; // Lightning for charging, Battery for discharging
-                    const timeText = displayMinutes > 0 ? `${Math.floor(displayMinutes / 60)}h ${displayMinutes % 60}m` : "--";
+                    // Charging: show minutes only | Discharging: show hours and minutes
+                    const timeText = displayMinutes > 0
+                        ? (isCharging ? `${displayMinutes}m` : `${Math.floor(displayMinutes / 60)}h ${displayMinutes % 60}m`)
+                        : "--";
                     document.getElementById('remainingHours').textContent = `${timeLabel} ${timeText}`;
 
                     document.getElementById('batteryRing').setAttribute('stroke-dasharray', `${battery}, 100`);


### PR DESCRIPTION
## Summary
Fixed the battery time display logic to correctly show charging vs. discharging states and improved the output power comparison to use the documented Reg 20 (totalWatts) instead of the undocumented Reg 39.

## Key Changes
- **Output power comparison**: Changed from using `output` (Reg 39, undocumented) to `totalWatts` (Reg 20, documented) for determining charging state
- **Time display format**: Updated to show minutes-only format when charging (`${displayMinutes}m`) and hours+minutes format when discharging (`${Math.floor(displayMinutes / 60)}h ${displayMinutes % 60}m`)
- **Code clarity**: Added explanatory comments documenting the rationale for using Reg 20 and the different time display formats

## Implementation Details
The charging state detection now consistently uses `totalWatts` for output comparison across both input conditions, ensuring more reliable state determination. The time display now provides more appropriate granularity for each state: minute-level precision during charging (typically shorter durations) and hour+minute format during discharging (typically longer durations).

https://claude.ai/code/session_016FyawqkqPNY13EcMaAyAv6