### PR TITLE
Update PROTOCOL.md with registers from diagnostic page

### DIFF
--- a/PROTOCOL.md
+++ b/PROTOCOL.md
@@ -31,29 +31,51 @@ The device uses different function codes (OpCodes) for different types of data:
 
 | Reg | Name | Format | Notes |
 |:----|:-----|:-------|:------|
-| 3   | **AC Input Watts** | Watts | Likely AC Input only. |
-| 4   | **DC Input Watts** | Watts | **Solar/DC Input**. |
+| 3   | **AC Input Watts** | Watts | AC Input power. |
+| 4   | **DC Input Watts** | Watts | **Solar/DC Input** power. |
 | 6   | **Total Input Watts** | Watts | Sum of AC (Reg 3) + DC (Reg 4). |
-| 13  | AC Charge Rate | 1-5 | Level 1 (~300W) to 5 (~1100W) |
-| 16  | Frequency | Hz &times; 10 | e.g., 500 = 50.0 Hz |
-| 18  | AC Out Voltage | V &times; 10 | e.g., 2300 = 230.0 V |
-| 19  | AC Out Frequency | Hz &times; 10 | e.g., 500 = 50.0 Hz |
-| 20  | Total Output Power | Watts | Sum of all outputs |
+| 13  | AC Charge Rate | 1-5 | Level 1 (~300W) to 5 (~1100W). |
+| 14  | **Max AC Input** | Watts | Max AC charge limit. Confirmed 1100W. |
+| 16  | Frequency Setting | Hz &times; 10 | e.g., 500 = 50.0 Hz. |
+| 18  | AC Out Voltage | V &times; 10 | e.g., 2300 = 230.0 V. |
+| 19  | AC Out Frequency | Hz &times; 10 | e.g., 500 = 50.0 Hz. |
+| 20  | **Total Output Power** | Watts | Sum of all outputs. **Use this for charging detection.** |
 | 21  | **AC Input Voltage** | V &times; 10 | e.g. 2317 = 231.7V. Measures Grid Voltage. **Note:** Matches Reg 18 (AC Out) when Bypass Relays are closed during charging. |
-| 22  | Battery Voltage | V &times; 100 | e.g., 4900 = 49.00 V |
-| 24  | USB Toggle State | 0/1 | Status of USB ports |
-| 25  | DC Toggle State | 0/1 | Status of DC ports (12V/Car) |
-| 26  | AC Toggle State | 0/1 | Status of Inverter |
-| 27  | Light State | 0-3 | 0=Off, 1=On, 2=SOS, 3=Flash |
-| 30  | USB-A Output | Watts &times; 10 | |
-| 31  | USB-A Output | Watts &times; 10 | |
-| 34-37| USB-C Output | Watts &times; 10 | |
+| 22  | Battery Voltage | V &times; 10 | e.g., 233 = 23.3V. |
+| 24  | USB Toggle State | 0/1 | Status of USB ports. |
+| 25  | DC Toggle State | 0/1 | Status of DC ports (12V/Car). |
+| 26  | AC Toggle State | 0/1 | Status of Inverter. |
+| 27  | Light State | 0-3 | 0=Off, 1=On, 2=Flash, 3=SOS. |
+| 30  | USB-A1 Output | Watts &times; 10 | First USB-A port output. |
+| 31  | USB-A2 Output | Watts &times; 10 | Second USB-A port output. |
+| 34  | USB-C1 Output | Watts &times; 10 | First USB-C port output. |
+| 35  | USB-C2 Output | Watts &times; 10 | Second USB-C port output. |
+| 36  | USB-C3 Output | Watts &times; 10 | Third USB-C port output. |
+| 37  | USB-C4 Output | Watts &times; 10 | Fourth USB-C port output. |
+| 39  | Output Watts (Legacy) | Watts | **Deprecated.** Use Reg 20 instead. |
+| 40  | Pack Config Voltage | V &times; 10 | Pack voltage calibration value. |
 | 41  | **Active Outputs** | Bitmask | **State Flags**: None=26, USB=640, DC=1152, AC=2052, Light=4224. |
-| 47-50| **Temp Sensors** | Celsius | **Unconfirmed**. Likely component temps (Inverter, Rectifier, Case). Values like 78, 73, 90 observed under load. |
-| 52  | **Temp Sensor** | Celsius | **Diagnostic Flag**. "Current" unit showed 180 (18.0C). |
+| 42  | State Flags 2 | Bitmask | Additional state flags. |
+| 47  | Temp Sensor 1 | Celsius | Component temperature (likely Inverter). |
+| 48  | Temp Sensor 2 | Celsius | Component temperature (likely Rectifier). |
+| 49  | Temp Sensor 3 | Celsius | Component temperature. |
+| 50  | Temp Sensor 4 | Celsius | Component temperature. |
+| 52  | Inverter Temp (Case) | Celsius | Case/inverter temperature. |
+| 53  | **Ext1 SOC** | Special | Extension Battery 1 SOC. 0=Missing, else (val-10)/10 = %. |
 | 54  | **Battery Capacity** | 0.1Ah | Battery Full Capacity. e.g. 374 = 37.4Ah. Used to calc SOH. |
-| 56  | **Main SOC** | 0.1% | State of Charge. e.g. 830 = 83.0% |
-| 59-62| **Timer Counters** | ? | **Do not use for settings display**. |
+| 55  | **Ext2 SOC** | Special | Extension Battery 2 SOC. 0=Missing, else (val-10)/10 = %. |
+| 56  | **Main SOC** | 0.1% | State of Charge. e.g. 830 = 83.0%. |
+| 57  | AC Silent Mode | 0/1 | Silent charging status. |
+| 58  | **Time to Full** | Minutes | Estimated minutes until battery is full (when charging). |
+| 59  | **Time to Empty** | Minutes | Estimated minutes until battery is empty (when discharging). |
+| 60  | AC Standby Counter | Minutes | Current AC standby countdown. |
+| 61  | DC Standby Counter | Minutes | Current DC standby countdown. |
+| 62  | USB Standby Counter | Raw | Current USB standby countdown. |
+| 66  | Discharge Limit | 0.1% | Current discharge limit setting. e.g. 100 = 10%. |
+| 67  | Charge Limit | 0.1% | Current charge limit setting. e.g. 1000 = 100%. |
+| 68  | Shutdown Timer | Raw | Machine shutdown countdown. |
+| 69  | **Fan Level** | 0-5 | Current fan speed level. |
+| 80  | CRC Checksum | Hex | Packet checksum value. |
 
 ---
 
@@ -61,26 +83,38 @@ The device uses different function codes (OpCodes) for different types of data:
 
 *Read/Write. Defines device behavior.*
 
-| 2 | Active Charge State | 1=Slow, 4=Const Current | 1, 4 | Correlates with Reg 13 settings |
-| 3 | AC Input Watts | Watts | 0 - 1100 | Rate at which AC is being drawn |
-| 4 | DC Input Watts | Watts | 0 - 500 | Solar / Car Input |
-| 5 | Unknown | ? | 0 | |
-| 6 | Total Input Watts | Watts | 0 - 1600 | Sum of AC + DC Input |
-| 7 | Unknown | ? | 0 | |
-| 25  | Enable DC | 0/1 | Toggle 12V DC |
-| 26  | Enable AC | 0/1 | Toggle Inverter |
-| 27  | Light Mode | 0-3 | Set Light mode |
-| 57  | Silent Charging | 0/1? | "Mute" toggle |
-| 59  | **Screen Timeout** | Minutes | 0 = Never. 0x1E = 30 mins. |
-| 60 | AC Standby Time | Minutes | 0 (Never) | Auto-off timer for AC |
-| 61 | DC Standby Time | Minutes | 0 | Auto-off timer for DC |
-| 62 | USB Standby Time | Minutes | 0 | Auto-off timer for USB |
-| 63 | Booking Charge | Minutes | 0 | Scheduled charging delay |
-| 64 | Power Off | 1 | 1 | Command to shutdown device |
-| 65 | Unknown | ? | 0 | |
-| 66 | Discharge Limit | % *10 | 0 (0%) | Stop discharging at this % (Battery Preserv.) |
-| 67 | Charge Limit (EPS) | %* 10 | 1000 (100%) | Stop charging at this % (Battery Preserv.) |
-| 68 | System Shutdown | Minutes | 60 | Auto-shutdown if idle |
+| Reg | Name | Format | Notes |
+|:----|:-----|:-------|:------|
+| 2   | Active Charge State | 1-4 | 1=Slow, 4=Const Current. Correlates with Reg 13. |
+| 3   | AC Input Watts | Watts | 0-1100. Rate at which AC is being drawn. |
+| 4   | DC Input Watts | Watts | 0-500. Solar/Car Input. |
+| 5   | Unknown Switch | 0/1 | Purpose unknown. |
+| 6   | Total Input Watts | Watts | 0-1600. Sum of AC + DC Input. |
+| 13  | AC Charge Rate | 1-5 | Charge level setting. |
+| 14  | AC Charge Max Limit | Watts | Max AC input limit. Confirmed 1100W. |
+| 16  | Frequency Setting | Hz &times; 10 | Output frequency (500 = 50Hz, 600 = 60Hz). |
+| 20  | Total Output / DC Max | Amps | DC output max current setting. |
+| 21  | AC Input Voltage | V &times; 10 | Measured AC input voltage. |
+| 22  | Battery Voltage | V &times; 10 | Measured battery voltage. |
+| 24  | USB Enabled | 0/1 | USB ports toggle. |
+| 25  | DC Enabled | 0/1 | 12V DC toggle. |
+| 26  | AC Enabled | 0/1 | Inverter toggle. |
+| 27  | Light Mode | 0-3 | 0=Off, 1=On, 2=Flash, 3=SOS. |
+| 32  | Firmware Version | Raw | Device firmware version identifier. |
+| 40  | Pack Voltage Calib 1 | Raw | Battery pack calibration value 1. |
+| 41  | Pack Voltage Calib 2 | Raw | Battery pack calibration value 2. |
+| 56  | Key Sound | 0/1 | Button beep toggle. |
+| 57  | Silent Charging | 0/1 | Mute charging sounds. |
+| 59  | **Screen Timeout** | Minutes | 0 = Never. e.g. 30 = 30 mins. |
+| 60  | AC Standby Time | Minutes | Auto-off timer for AC. 0 = Never. |
+| 61  | DC Standby Time | Minutes | Auto-off timer for DC. 0 = Never. |
+| 62  | USB Standby Time | Seconds | Auto-off timer for USB. 0 = Never. |
+| 63  | Booking Charge | Minutes | Scheduled charging delay. |
+| 64  | Power Off | 1 | Command to shutdown device. |
+| 66  | Discharge Limit | 0.1% | Stop discharging at this %. e.g. 100 = 10%. |
+| 67  | Charge Limit (EPS) | 0.1% | Stop charging at this %. e.g. 1000 = 100%. |
+| 68  | Machine Shutdown | Minutes | Auto-shutdown if idle. |
+| 80  | CRC Checksum | Hex | Packet checksum. |
 
 ---
 


### PR DESCRIPTION
STATUS Registers (0x1104) - Added:
- Reg 14: Max AC Input (1100W)
- Reg 39: Output Watts (Legacy) - marked deprecated, use Reg 20
- Reg 40: Pack Config Voltage
- Reg 42: State Flags 2
- Reg 53: Ext1 SOC (extension battery 1)
- Reg 55: Ext2 SOC (extension battery 2)
- Reg 57: AC Silent Mode
- Reg 58: Time to Full (minutes)
- Reg 59: Time to Empty (minutes) - corrected from "Timer Counters"
- Reg 60-62: Standby counters
- Reg 66-67: Discharge/Charge limits
- Reg 68: Shutdown Timer
- Reg 69: Fan Level
- Reg 80: CRC Checksum
- Split USB-A and USB-C into individual port registers (30-31, 34-37)
- Split temp sensors into individual registers (47-50, 52)

SETTINGS Registers (0x1103) - Added:
- Reg 13-14: AC Charge Rate/Max Limit
- Reg 16: Frequency Setting
- Reg 20-22: Output/Voltage settings
- Reg 24: USB Enabled
- Reg 32: Firmware Version
- Reg 40-41: Pack Voltage Calibration
- Reg 56: Key Sound
- Reg 80: CRC Checksum
- Fixed table formatting with proper headers

https://claude.ai/code/session_016FyawqkqPNY13EcMaAyAv6