### PR TITLE
Final master protocol update: Reg 42 bitmask fault detection, Reg 52/…

### DIFF
--- a/PROTOCOL.md
+++ b/PROTOCOL.md
@@ -16,6 +16,8 @@ All data is Big-Endian. Packets generally follow this structure:
 |:-------|:-------|:--------|:--------|:--------|:---------|
 | `11`   | `04`   | `00`    | `00`    | ...     | `CRC`    |
 
+Header byte `0x11` is the Modbus slave address (Register 17). Always `0x11` over BLE.
+
 ### Payload Types
 
 The device uses different function codes (OpCodes) for different types of data:
@@ -31,21 +33,31 @@ The device uses different function codes (OpCodes) for different types of data:
 
 | Reg | Name | Format | Notes |
 |:----|:-----|:-------|:------|
-| 3   | **AC Input Watts** | Watts | AC Input power. |
+| 2   | **AC Charge Speed Status** | 1-5 | Current charge speed level. |
+| 3   | **AC Input Watts** | Watts | AC Input power (actual). |
 | 4   | **DC Input Watts** | Watts | **Solar/DC Input** power. |
 | 6   | **Total Input Watts** | Watts | Sum of AC (Reg 3) + DC (Reg 4). |
-| 13  | AC Charge Rate | 1-5 | Level 1 (~300W) to 5 (~1100W). |
-| 14  | **Max AC Input** | Watts | Max AC charge limit. Confirmed 1100W. |
-| 16  | Frequency Setting | Hz &times; 10 | e.g., 500 = 50.0 Hz. |
+| 8   | **Active Error Code** | Raw | **Safety Lockout.** 0=Normal, 78=Inverter Fault, 79=AC Charging Interrupted. See [Error Code Logic](#6-error-code-logic-reg-8--reg-42). |
 | 18  | AC Out Voltage | V &times; 10 | e.g., 2300 = 230.0 V. |
 | 19  | AC Out Frequency | Hz &times; 10 | e.g., 500 = 50.0 Hz. |
 | 20  | **Total Output Power** | Watts | Sum of all outputs. **Use this for charging detection.** |
-| 21  | **AC Input Voltage** | V &times; 10 | e.g. 2317 = 231.7V. Measures Grid Voltage. **Note:** Matches Reg 18 (AC Out) when Bypass Relays are closed during charging. |
+| 21  | **Multiplexed Voltage** | V &times; 10 | **Charging:** AC Input Voltage (e.g. 2317 = 231.7V). **Discharging:** Internal DC Bus Voltage. Context-dependent. |
+| 30  | USB-A1 Output | Watts &times; 10 | First USB-A port output. |
+| 31  | USB-A2 Output | Watts &times; 10 | Second USB-A port output. |
+| 41  | **Active Port Flags** | Bitmask | Bit 9 (0x0200)=USB, Bit 10 (0x0400)=DC, Bit 11 (0x0800)=AC, Bit 12 (0x1000)=LED. |
+| 42  | **Hardware GPIO & Fault Mask** | Bitmask | **Bit 15 (0x8000):** System Warning / Non-Critical Latch (often always on). **Bits 13-14 (0x6000):** CRITICAL FAULT MASK. **Bits 0-12:** Output MOSFET Status (e.g., +984 when USB/DC on). Check `(Reg42 & 0x6000) > 0` for faults. See [Error Code Logic](#6-error-code-logic-reg-8--reg-42). |
+| 47  | Protocol Version | Constant | Always 12288 (0x3000). Not a sensor. |
+| 48  | **System Status Flags** | Bitmask | **0x8000**=Charging, **0x4000**=Standby, **0x0008**=Error Pending. |
+| 54  | **Battery Capacity** | 0.1Ah | Battery Full Capacity. e.g. 374 = 37.4Ah. Used to calc SOH. |
+| 56  | **Main SOC** | 0.1% | State of Charge. e.g. 830 = 83.0%. |
+| 58  | **Time to Full** | Minutes | Estimated minutes until battery is full (when charging). |
+| 59  | **Time to Empty** | Minutes | Estimated minutes until battery is empty (when discharging). |
+
+### Additional STATUS Registers (Informational)
+
+| Reg | Name | Format | Notes |
+|:----|:-----|:-------|:------|
 | 22  | Battery Voltage | V &times; 10 | e.g., 233 = 23.3V. |
-| 24  | USB Toggle State | 0/1 | Status of USB ports. |
-| 25  | DC Toggle State | 0/1 | Status of DC ports (12V/Car). |
-| 26  | AC Toggle State | 0/1 | Status of Inverter. |
-| 27  | Light State | 0-3 | 0=Off, 1=On, 2=Flash, 3=SOS. |
 | 30  | USB-A1 Output | Watts &times; 10 | First USB-A port output. |
 | 31  | USB-A2 Output | Watts &times; 10 | Second USB-A port output. |
 | 34  | USB-C1 Output | Watts &times; 10 | First USB-C port output. |
@@ -54,20 +66,10 @@ The device uses different function codes (OpCodes) for different types of data:
 | 37  | USB-C4 Output | Watts &times; 10 | Fourth USB-C port output. |
 | 39  | Output Watts (Legacy) | Watts | **Deprecated.** Use Reg 20 instead. |
 | 40  | Pack Config Voltage | V &times; 10 | Pack voltage calibration value. |
-| 41  | **Active Outputs** | Bitmask | **State Flags**: None=26, USB=640, DC=1152, AC=2052, Light=4224. |
-| 42  | State Flags 2 | Bitmask | Additional state flags. |
-| 47  | Temp Sensor 1 | Celsius | Component temperature (likely Inverter). |
-| 48  | Temp Sensor 2 | Celsius | Component temperature (likely Rectifier). |
-| 49  | Temp Sensor 3 | Celsius | Component temperature. |
-| 50  | Temp Sensor 4 | Celsius | Component temperature. |
-| 52  | Inverter Temp (Case) | Celsius | Case/inverter temperature. |
+| 52  | **Model Constant** | Raw | **NOT a temperature sensor.** Fixed at 180 for Fossibot, 0 for Aferiy. Ignore for thermal monitoring. |
 | 53  | **Ext1 SOC** | Special | Extension Battery 1 SOC. 0=Missing, else (val-10)/10 = %. |
-| 54  | **Battery Capacity** | 0.1Ah | Battery Full Capacity. e.g. 374 = 37.4Ah. Used to calc SOH. |
 | 55  | **Ext2 SOC** | Special | Extension Battery 2 SOC. 0=Missing, else (val-10)/10 = %. |
-| 56  | **Main SOC** | 0.1% | State of Charge. e.g. 830 = 83.0%. |
 | 57  | AC Silent Mode | 0/1 | Silent charging status. |
-| 58  | **Time to Full** | Minutes | Estimated minutes until battery is full (when charging). |
-| 59  | **Time to Empty** | Minutes | Estimated minutes until battery is empty (when discharging). |
 | 60  | AC Standby Counter | Minutes | Current AC standby countdown. |
 | 61  | DC Standby Counter | Minutes | Current DC standby countdown. |
 | 62  | USB Standby Counter | Raw | Current USB standby countdown. |
@@ -85,36 +87,50 @@ The device uses different function codes (OpCodes) for different types of data:
 
 | Reg | Name | Format | Notes |
 |:----|:-----|:-------|:------|
-| 2   | Active Charge State | 1-4 | 1=Slow, 4=Const Current. Correlates with Reg 13. |
-| 3   | AC Input Watts | Watts | 0-1100. Rate at which AC is being drawn. |
-| 4   | DC Input Watts | Watts | 0-500. Solar/Car Input. |
-| 5   | Unknown Switch | 0/1 | Purpose unknown. |
-| 6   | Total Input Watts | Watts | 0-1600. Sum of AC + DC Input. |
-| 13  | AC Charge Rate | 1-5 | Charge level setting. |
-| 14  | AC Charge Max Limit | Watts | Max AC input limit. Confirmed 1100W. |
+| 5   | **Master System Enable** | 0/1 | 0=Off, 1=On. Forced to 0 during Critical Faults (Reg 42 bits 13-14). |
+| 11  | **Hardware ID** | Raw | 1536 (0x0600) = US Aferiy, 512 (0x0200) = EU Fossibot. |
+| 13  | **AC Charge Speed Setpoint** | 1-5 | Charge level setting. |
+| 14  | **Max Charge Wattage** | Watts | 1500 (US), 1100 (EU). |
 | 16  | Frequency Setting | Hz &times; 10 | Output frequency (500 = 50Hz, 600 = 60Hz). |
-| 20  | Total Output / DC Max | Amps | DC output max current setting. |
-| 21  | AC Input Voltage | V &times; 10 | Measured AC input voltage. |
-| 22  | Battery Voltage | V &times; 10 | Measured battery voltage. |
-| 24  | USB Enabled | 0/1 | USB ports toggle. |
-| 25  | DC Enabled | 0/1 | 12V DC toggle. |
-| 26  | AC Enabled | 0/1 | Inverter toggle. |
-| 27  | Light Mode | 0-3 | 0=Off, 1=On, 2=Flash, 3=SOS. |
+| 19  | **Max AC Input Current** | dA | 1600 = 16.0A (120V US), 500 = 5.0A (230V EU). |
+| 24  | **USB Toggle** | 0/1 | USB ports toggle. |
+| 25  | **DC Toggle** | 0/1 | 12V DC toggle. |
+| 26  | **AC Toggle** | 0/1 | Inverter toggle. |
+| 27  | **Light Mode** | 0-3 | 0=Off, 1=On, 2=Flash, 3=SOS. |
 | 32  | Firmware Version | Raw | Device firmware version identifier. |
-| 40  | Pack Voltage Calib 1 | Raw | Battery pack calibration value 1. |
-| 41  | Pack Voltage Calib 2 | Raw | Battery pack calibration value 2. |
-| 56  | Key Sound | 0/1 | Button beep toggle. |
+| 56  | **Key Sound** | 0/1 | Button beep toggle. |
 | 57  | Silent Charging | 0/1 | Mute charging sounds. |
-| 59  | **Screen Timeout** | Minutes | 0 = Never. e.g. 30 = 30 mins. |
+| 59  | Screen Timeout | Minutes | 0 = Never. e.g. 30 = 30 mins. |
 | 60  | AC Standby Time | Minutes | Auto-off timer for AC. 0 = Never. |
 | 61  | DC Standby Time | Minutes | Auto-off timer for DC. 0 = Never. |
 | 62  | USB Standby Time | Seconds | Auto-off timer for USB. 0 = Never. |
 | 63  | Booking Charge | Minutes | Scheduled charging delay. |
 | 64  | Power Off | 1 | Command to shutdown device. |
-| 66  | Discharge Limit | 0.1% | Stop discharging at this %. e.g. 100 = 10%. |
-| 67  | Charge Limit (EPS) | 0.1% | Stop charging at this %. e.g. 1000 = 100%. |
+| 66  | **Discharge Limit** | 0.1% | Min SoC %. Stop discharging at this %. e.g. 100 = 10%. |
+| 67  | **Charge Limit** | 0.1% | Max SoC %. Stop charging at this %. e.g. 1000 = 100%. |
 | 68  | Machine Shutdown | Minutes | Auto-shutdown if idle. |
 | 80  | CRC Checksum | Hex | Packet checksum. |
+
+### Writable Register Safety Whitelist
+
+**WARNING: Fossibot firmware does NOT validate register write values. Writing an out-of-range value can permanently brick a device.**
+
+| Register | Allowed Values |
+|:---------|:---------------|
+| 20 (Max Charging Current) | 1-20 (integers) |
+| 24 (USB Output) | 0 or 1 |
+| 25 (DC Output) | 0 or 1 |
+| 26 (AC Output) | 0 or 1 |
+| 27 (LED) | 0, 1, 2, 3 |
+| 57 (AC Silent Charging) | 0 or 1 |
+| 59 (USB Standby Time) | 0, 3, 5, 10, 30 |
+| 60 (AC Standby Time) | 0, 480, 960, 1440 |
+| 61 (DC Standby Time) | 0, 480, 960, 1440 |
+| 62 (Screen Rest Time) | 0, 180, 300, 600, 1800 |
+| 63 (Stop Charge After) | 0-1440 (minutes) |
+| 66 (Discharge Limit) | 0-1000 (0.1% units) |
+| 67 (Charging Limit) | 0-1000 (0.1% units) |
+| 68 (Sleep Time) | 5, 10, 30, 480 |
 
 ---
 
@@ -125,6 +141,8 @@ The device uses different function codes (OpCodes) for different types of data:
 | Reg | Name | Value | Description |
 |:----|:-----|:------|:------------|
 | 64  | Power Off | 1 | Shuts down the entire machine. |
+
+---
 
 ## 4. Network Configuration (0x1107)
 
@@ -161,6 +179,8 @@ The device sends status updates containing the `0x07` OpCode.
 * `11 07 01 ...` -> Connected
 * `11 07 01 ...` -> Connected
 
+---
+
 ## 5. Protocol Discovery Findings
 
 Recent analysis reveals the device stack is likely based on Espressif AT commands.
@@ -195,6 +215,49 @@ Structure: `Header(11) Op(06) RegHi RegLo ValHi ValLo CRC_Hi CRC_Lo`.
 The correct CRC byte order is **Hi-Byte First** (Modbus Standard), e.g., `0xAA 0xBB`.
 Legacy code/findings suggesting `Lo-Hi` were incorrect and caused packet rejection.
 
+---
+
+## 6. Error Code Logic (Reg 8 + Reg 42)
+
+### Error Codes (Reg 8)
+
+| Code | Meaning | Notes |
+|:-----|:--------|:------|
+| 0    | **Normal** | No error. |
+| 78   | **Inverter Fault** | AC inverter offline. DC Charging via Solar still works. |
+| 79   | **AC Charging Interrupted** | Safety Lockout. Triggers for BOTH critical hardware failures AND environmental protection (Cold/Hot). |
+
+### Fault Detection (Reg 42)
+
+Reg 42 is a **mixed-purpose bitmask** containing both status bits and fault bits. You **cannot** simply check `if (Reg42 > 0)` — the lower bits reflect normal MOSFET state.
+
+**Bitmask Layout:**
+
+| Bits | Mask | Meaning |
+|:-----|:-----|:--------|
+| Bit 15 | 0x8000 | System Warning / Non-Critical Latch (often always on) |
+| Bits 13-14 | **0x6000** | **CRITICAL FAULT MASK** |
+| Bits 0-12 | 0x1FFF | Output MOSFET Status (e.g., +984 when USB/DC is on) |
+
+**Implementation:**
+
+```javascript
+const isCriticalFault = (Reg42 & 0x6000) > 0;
+```
+
+### Combined Logic (Error Classification)
+
+When Reg 8 reports Error 79:
+- **IF `(Reg42 & 0x6000) > 0`:** Hardware Failure (critical).
+- **IF `(Reg42 & 0x6000) == 0`:** Environmental Protection (Cold/Hot Temperature).
+
+### UI Display Rules
+
+- **Status Text Priority:** Error (Reg 48 bit 3) > Charging (Reg 48 bit 15) > Standby (Reg 48 bit 14).
+- If Error 79 is present with NO critical bits in Reg 42, display **"Temp/Safety Protection"** instead of "System Failure".
+
+---
+
 ## 7. BLE Service Map (Discovered)
 
 Based on exploration of `0xA002` and `0xA003`.
@@ -215,17 +278,6 @@ The presence of `Y_DHK` and `LOCAL_KEY` in `0xC301` confirms this is a **Tuya-ba
 | `0xC306` | ? | ? | - |
 | `0xC307` | Read | ? | Static Value: `0x30` ("0") |
 
-## 8. Candidate Registers for Investigation
-
-Based on recent "Dump" analysis, these registers show interesting activity:
-
-| Register | Value (Idle) | Value (Load) | Hypothesis | Test to Verify |
-| :--- | :--- | :--- | :--- | :--- |
-| `R18` | 33 | 115? | **Temp?** / Power? | Watch while heating up. |
-| `R50` | 0 | 42 | **Inverter Temp?** | Watch during AC use. |
-| `R60` | 0 | 480 | **Fan Speed?** | Watch when fan spins up. |
-| `R19` | 500 | 500 | **Frequency?** | 50.0 Hz? |
-
 ### Service `0xA003` (Auxiliary?)
 
 | UUID | Props | Description | Notes |
@@ -233,6 +285,8 @@ Based on recent "Dump" analysis, these registers show interesting activity:
 | `0xC400` | Read | ? | Static Value: `0x30` ("0") |
 | `0xC401` | Read | ? | Static Value: `0x30` ("0") |
 
+---
+
 ## CRC Calculation
 
-The protocol uses a custom CRC-16 checksum. See `calculateChecksum()` in `index.html` for implementation details.
+The protocol uses a custom CRC-16 checksum with polynomial 0xA001 (Modbus standard). See `calculateChecksum()` in `index.html` for implementation details.

--- a/index.html
+++ b/index.html
@@ -1482,7 +1482,7 @@
                            background: #ef4444; color: #fff; padding: 6px 16px; border-radius: 8px;
                            font-size: 0.75rem; font-weight: bold; text-align: center; width: 85%;
                            box-shadow: 0 2px 8px rgba(239,68,68,0.4); animation: toast-in 0.3s ease;">
-                    Protection Fault Active (Reg 42) - Check Device
+                    System Alert
                 </div>
             </div>
 
@@ -2527,11 +2527,19 @@ Example format:
 
                     document.getElementById('outputWatts').textContent = output;
 
-                    // System Status from Reg 48 flags (0x8000=AC Charging, 0x4000=Inverter Standby, 0x0008=Error)
+                    // System Status: Error > Charging > Standby
+                    // Reg 48 flags: 0x8000=Charging, 0x4000=Standby, 0x0008=Error
+                    // Reg 8: 0=Normal, 78=Inverter Fault, 79=Safety Lockout
                     let sysStatus = '';
-                    if (statusFlags & 0x8000) sysStatus = 'Charging';
+                    if ((statusFlags & 0x0008) || errorCode > 0) {
+                        const isCritHW = (protFlags & 0x6000) > 0;
+                        if (errorCode === 79 && !isCritHW) sysStatus = 'Temp Protection';
+                        else if (errorCode === 78) sysStatus = 'Inverter Fault';
+                        else if (errorCode > 0) sysStatus = `Error ${errorCode}`;
+                        else sysStatus = 'Error';
+                    }
+                    else if (statusFlags & 0x8000) sysStatus = 'Charging';
                     else if (statusFlags & 0x4000) sysStatus = 'Standby';
-                    else if (statusFlags & 0x0008) sysStatus = 'Error';
                     else if (statusFlags > 0) sysStatus = '0x' + statusFlags.toString(16).toUpperCase();
                     else sysStatus = '--';
                     document.getElementById('sysWatts').textContent = sysStatus;
@@ -2555,12 +2563,28 @@ Example format:
                     document.getElementById('batteryRing').setAttribute('stroke-dasharray', `${battery}, 100`);
                     document.getElementById('batteryRing').style.color = battery < 20 ? "#ef4444" : "#60a5fa";
 
-                    // Protection Fault Warning (Reg 42: 0 = OK, non-zero = Critical Fault)
+                    // Protection Fault Warning (Reg 42 bitmask + Reg 8 error code)
+                    // Reg 42: Bits 13-14 (0x6000) = Critical Fault. Bits 0-12 = normal MOSFET status.
+                    // Reg 8: 0=Normal, 78=Inverter Fault, 79=Safety Lockout
                     const protFlags = getRegLocal(42);
+                    const errorCode = getRegLocal(8);
+                    const isCriticalFault = (protFlags & 0x6000) > 0;
                     const protWarn = document.getElementById('protectionWarning');
                     if (protWarn) {
-                        if (protFlags !== 0) {
-                            protWarn.textContent = `Protection Fault Active (0x${protFlags.toString(16).toUpperCase()}) - Check Device`;
+                        if (errorCode === 79 && !isCriticalFault) {
+                            // Error 79 + no critical HW bits = Environmental protection (Cold/Hot)
+                            protWarn.textContent = 'Temp/Safety Protection Active';
+                            protWarn.style.background = '#d97706';
+                            protWarn.classList.remove('hidden');
+                        } else if (isCriticalFault) {
+                            // Critical hardware fault (bits 13/14 set)
+                            protWarn.textContent = `Hardware Fault (0x${protFlags.toString(16).toUpperCase()}) - Check Device`;
+                            protWarn.style.background = '#ef4444';
+                            protWarn.classList.remove('hidden');
+                        } else if (errorCode === 78) {
+                            // Inverter fault - solar still works
+                            protWarn.textContent = 'Inverter Fault (DC/Solar OK)';
+                            protWarn.style.background = '#d97706';
                             protWarn.classList.remove('hidden');
                         } else {
                             protWarn.classList.add('hidden');
@@ -2826,7 +2850,7 @@ Example format:
             const inTot = getReg(6);
             const capAh = getReg(54); // 374 = 37.4
             const soh = (capAh > 0) ? ((capAh / 400.0) * 100).toFixed(1) : 0;
-            const tempDiag = getReg(52); // 180 = 18.0
+            const modelConst = getReg(52); // Model Constant: 180=Fossibot, 0=Aferiy (NOT temperature)
 
             const diagEl = document.getElementById('diagnostics');
             if (diagEl) {
@@ -2835,14 +2859,14 @@ Example format:
                          <span>⚡ ${(valACFreq / 10).toFixed(1)}Hz</span>
                          <span>🔋 ${(valBatV / 100).toFixed(1)}V</span>
                          <span style="color:var(--text-green)">🏥 SOH: ${soh}%</span>
-                         <span>🌡️ ${tempDiag > 0 ? (tempDiag / 10).toFixed(1) : '--'}°C</span>
+                         <span>Model: ${modelConst}</span>
                          <span>🌀 Lvl ${fanLvl}</span>
                     </div>
                     <div style="font-size: 0.7rem; color: #aaa; margin-top: 0.25rem;">
                         <strong>New Findings:</strong><br>
                         Inputs: AC(R3):${inAC}W + DC(R4):${inDC}W = Tot(R6):${inTot}W <br>
                         Cap: ${(capAh / 10).toFixed(1)}Ah (Ref: 40Ah) <br>
-                        AC Input V (R21): ${(getReg(21) / 10).toFixed(1)}V <br>
+                        Bus/AC V (R21): ${(getReg(21) / 10).toFixed(1)}V <br>
                         Active Outputs (R41): ${getReg(41)}
                     </div>
                 `;
@@ -3342,14 +3366,14 @@ Example format:
             5: { name: 'Unknown (0)', unit: '' },
             6: { name: 'Total Input', unit: 'W' },
             7: { name: 'Error/Warning Code?', format: 'flags' },     // 0 during cold temp warning, needs more data
-            8: { name: 'Error Code', format: 'raw' },                // Numeric error ID (e.g. 79) corresponding to Reg 42 bitmask
+            8: { name: 'Active Error Code', format: 'raw' },         // 0=Normal, 78=Inverter Fault, 79=Safety Lockout (Cold/Hot/HW)
             13: { name: 'AC Charge Rate', format: 'charge_level' },
             14: { name: 'Max AC Input', format: 'watt' },         // Confirmed 1100
             16: { name: 'Frequency Set', format: 'freq01' },
             18: { name: 'AC Out Voltage', format: 'volt' },
             19: { name: 'AC Out Frequency', format: 'freq01' },   // Value 500 = 50.0Hz
             20: { name: 'Total Output', format: 'watt' },
-            21: { name: 'System State?', format: 'raw' },            // 15=Cold temp protection?, 21=Normal operation? - thermometer+L icon when 15
+            21: { name: 'Multiplexed Voltage', format: 'volt' },       // Charging: AC Input V (x10). Discharging: Internal DC Bus Voltage
             22: { name: 'Battery Voltage', format: 'volt' },      // Settings has 233 (23.3V?)
             24: { name: 'USB Toggle', format: 'toggle' },
             25: { name: 'DC Toggle', format: 'toggle' },
@@ -3363,13 +3387,13 @@ Example format:
             37: { name: 'USB-C4 Out', format: 'watt01' },
             39: { name: 'Total Output (Old?)', format: 'watt' },
             40: { name: 'Pack Config V? (x10)', format: 'volt' },
-            41: { name: 'Capability Flags?', format: 'flags' },       // 0x0804 during cold warning, 0x0CA4 normal - bits 5,7,10 = input/charge capabilities?
-            42: { name: 'Protection Flags (Critical)', format: 'flags' }, // 0xE000 (bits 13,14,15) = Critical Hardware Failure. 0 = OK. Correlates with Reg 8 error code
+            41: { name: 'Active Port Flags', format: 'flags' },        // Bit9=USB, Bit10=DC, Bit11=AC, Bit12=LED
+            42: { name: 'HW GPIO & Fault Mask', format: 'flags' },    // Bit15=Warning latch, Bits13-14(0x6000)=CRITICAL FAULT, Bits0-12=MOSFET status
             47: { name: 'Hardware Constant (0x3000)', format: 'flags' }, // Identical across all 5 devices - not a sensor
             48: { name: 'System Status Flags', format: 'flags' },    // 0x8000=AC Charging, 0x4000=Inverter Standby, 0x0008=Error Pending
             49: { name: 'Unknown Reg 49', format: 'raw' },
             50: { name: 'Unknown Reg 50', format: 'raw' },
-            52: { name: 'Device Specific (Model?)', format: 'raw' }, // 180 on Aferiy, 0 on Fossibot - not case temp
+            52: { name: 'Model Constant', format: 'raw' },            // Fixed: 180=Fossibot, 0=Aferiy. NOT temperature. Ignore for thermal.
             53: { name: 'Ext1 SOC', format: 'ext_soc' },
             54: { name: 'Battery Full Capacity (0.1Ah)', format: 'capacity' }, // 374=37.4Ah (Aferiy), 762=76.2Ah (Fossibot)
             55: { name: 'Ext2 SOC', format: 'ext_soc' },
@@ -3389,13 +3413,13 @@ Example format:
 
         // Settings Register Map (0x1103)
         const SETTINGS_REGS = {
-            5: 'Master System Enable (0/1)',      // Forced to 0 during Critical Faults (Reg 42)
-            11: 'Hardware/Model ID',              // 0x0600=US, 0x0200=EU Type A, 0x0D00=EU Type B
+            5: 'Master System Enable (0/1)',      // Forced to 0 during Critical Faults (Reg 42 bits 13-14)
+            11: 'Hardware ID',                     // 1536(0x0600)=US Aferiy, 512(0x0200)=EU Fossibot
             13: 'AC Charge Speed Setting (1-5)',
             14: 'Max Charge Wattage (W)',         // 1500 (US), 1100 (EU)
             16: 'Frequency Setting (Hz/10)',
             19: 'Max AC Input Current (dA)',      // 1600=16.0A (120V US), 500=5.0A (230V EU)
-            20: 'Total Output / DC Max (A)',
+            20: 'Max Charging Current (1-20A)',
             21: 'AC Input Voltage',
             22: 'Battery Voltage',
             24: 'USB Enabled',


### PR DESCRIPTION
…8/21 corrections

- Reg 42: Now uses bitmask (0x6000) for critical faults instead of != 0 check. Lower bits are normal MOSFET status, not faults.
- Reg 52: Reclassified from temperature to Model Constant (180=Fossibot, 0=Aferiy)
- Reg 8: Documented as Safety Lockout (0=Normal, 78=Inverter, 79=AC Interrupted)
- Reg 21: Renamed to Multiplexed Voltage (AC Input when charging, DC Bus when discharging)
- Error logic: Error 79 + no critical bits = Temp/Safety Protection (amber), Error 79 + critical bits = Hardware Fault (red)
- Status priority: Error > Charging > Standby
- Added writable register safety whitelist to PROTOCOL.md
- Removed Reg 52 temperature display from diagnostics

https://claude.ai/code/session_0145csb62GJU477BriwJzhZD