### PR TITLE
Fix system status error detection to use authoritative error code

### DIFF
--- a/index.html
+++ b/index.html
@@ -2532,15 +2532,16 @@ Example format:
                     const errorCode = getRegLocal(8);
 
                     // System Status: Error > Charging > Standby
-                    // Reg 48 flags: 0x8000=Charging, 0x4000=Standby, 0x0008=Error
+                    // Reg 48 flags: 0x8000=Charging, 0x4000=Standby, 0x0008=Error Pending (transient)
                     // Reg 8: 0=Normal, 78=Inverter Fault, 79=Safety Lockout
+                    // NOTE: Reg 48 bit 0x0008 is set transiently during AC inverter state changes
+                    // and is not a reliable error indicator. Use Reg 8 (errorCode) as authoritative source.
                     let sysStatus = '';
-                    if ((statusFlags & 0x0008) || errorCode > 0) {
+                    if (errorCode > 0) {
                         const isCritHW = (protFlags & 0x6000) > 0;
                         if (errorCode === 79 && !isCritHW) sysStatus = 'Temp Protection';
                         else if (errorCode === 78) sysStatus = 'Inverter Fault';
-                        else if (errorCode > 0) sysStatus = `Error ${errorCode}`;
-                        else sysStatus = 'Error';
+                        else sysStatus = `Error ${errorCode}`;
                     }
                     else if (statusFlags & 0x8000) sysStatus = 'Charging';
                     else if (statusFlags & 0x4000) sysStatus = 'Standby';


### PR DESCRIPTION
## Summary
Improved system status error detection by removing reliance on a transient flag and using the authoritative error code register instead.

## Key Changes
- Removed `statusFlags & 0x0008` from error detection logic, as this flag is set transiently during AC inverter state changes and is not a reliable error indicator
- Changed error detection to exclusively use `errorCode` (Register 8) as the authoritative source for error states
- Simplified error status message logic by removing unreachable `else` clause that would never execute
- Added clarifying comments documenting that Register 48 bit 0x0008 is transient and should not be used for error detection

## Implementation Details
The system status determination follows this priority: Error > Charging > Standby. Previously, the error check combined two conditions that could produce false positives. Register 48's 0x0008 bit toggles during normal AC inverter state transitions, causing spurious error status displays. Register 8 provides the definitive error state and is now the sole indicator for error conditions.

https://claude.ai/code/session_01RJweAAPcxJRyLFComu7QkK