### PR TITLE
Fix critical fault detection logic to require Reg 8 error code

### DIFF
--- a/PROTOCOL.md
+++ b/PROTOCOL.md
@@ -297,6 +297,8 @@ Reg 42 is a **mixed-purpose bitmask** containing both status bits and fault bits
 | Bits 13-14 | **0x6000** | **CRITICAL FAULT MASK** |
 | Bits 0-12 | 0x1FFF | Output MOSFET Status (e.g., +984 when USB/DC is on) |
 
+**Important:** Bits 13-14 can be set during normal device operation (e.g., Reg 42 = `0xE3D8` while healthy). Do **not** use `isCriticalFault` alone as an error indicator — it must be combined with Reg 8.
+
 **Implementation:**
 
 ```javascript
@@ -308,6 +310,8 @@ const isCriticalFault = (Reg42 & 0x6000) > 0;
 When Reg 8 reports Error 79:
 - **IF `(Reg42 & 0x6000) > 0`:** Hardware Failure (critical).
 - **IF `(Reg42 & 0x6000) == 0`:** Environmental Protection (Cold/Hot Temperature).
+
+If Reg 8 = 0 (Normal), do **not** show any fault — even if bits 13-14 are set in Reg 42.
 
 ### UI Display Rules
 

--- a/index.html
+++ b/index.html
@@ -2571,18 +2571,20 @@ Example format:
                     // Protection Fault Warning (Reg 42 bitmask + Reg 8 error code)
                     // Reg 42: Bits 13-14 (0x6000) = Critical Fault. Bits 0-12 = normal MOSFET status.
                     // Reg 8: 0=Normal, 78=Inverter Fault, 79=Safety Lockout
+                    // NOTE: Bits 13-14 can be set during normal operation (e.g. 0xE3D8).
+                    // Only treat as fault when errorCode === 79 confirms an actual error.
                     const isCriticalFault = (protFlags & 0x6000) > 0;
                     const protWarn = document.getElementById('protectionWarning');
                     if (protWarn) {
-                        if (errorCode === 79 && !isCriticalFault) {
+                        if (errorCode === 79 && isCriticalFault) {
+                            // Error 79 + critical HW bits = Hardware Failure
+                            protWarn.textContent = `Hardware Fault (0x${protFlags.toString(16).toUpperCase()}) - Check Device`;
+                            protWarn.style.background = '#ef4444';
+                            protWarn.classList.remove('hidden');
+                        } else if (errorCode === 79 && !isCriticalFault) {
                             // Error 79 + no critical HW bits = Environmental protection (Cold/Hot)
                             protWarn.textContent = 'Temp/Safety Protection Active';
                             protWarn.style.background = '#d97706';
-                            protWarn.classList.remove('hidden');
-                        } else if (isCriticalFault) {
-                            // Critical hardware fault (bits 13/14 set)
-                            protWarn.textContent = `Hardware Fault (0x${protFlags.toString(16).toUpperCase()}) - Check Device`;
-                            protWarn.style.background = '#ef4444';
                             protWarn.classList.remove('hidden');
                         } else if (errorCode === 78) {
                             // Inverter fault - solar still works


### PR DESCRIPTION
## Summary
Fixed a critical bug in the protection fault warning logic where hardware faults were being incorrectly detected based solely on Reg 42 bits 13-14, without verifying the actual error state via Reg 8. This caused false hardware fault alerts during normal device operation.

## Key Changes
- **Inverted the fault detection condition**: Changed from `errorCode === 79 && !isCriticalFault` to `errorCode === 79 && isCriticalFault` to properly distinguish between hardware failures and environmental protection
- **Reordered conditional logic**: Moved the hardware fault case (error 79 + critical bits) before the environmental protection case (error 79 + no critical bits) for clearer intent
- **Updated documentation**: Added clarification in PROTOCOL.md that bits 13-14 can be set during normal operation and must be combined with Reg 8 error code for proper fault detection

## Implementation Details
The fix ensures that:
1. **Hardware Fault** (red alert): Only triggered when `errorCode === 79` AND `(Reg42 & 0x6000) > 0`
2. **Environmental Protection** (orange alert): Triggered when `errorCode === 79` AND `(Reg42 & 0x6000) == 0`
3. **No alert**: When `errorCode !== 79`, even if bits 13-14 are set in Reg 42

This prevents false positives where normal register values like `0xE3D8` would incorrectly trigger hardware fault warnings.

https://claude.ai/code/session_01MsU5K9rQMw5imCwyZ46zUB