### PR TITLE
Fix mismatched unit on dashboard remaining-time display

### DIFF
--- a/index.html
+++ b/index.html
@@ -1462,7 +1462,7 @@
                             </div>
                         </div>
                         <div class="dash-sub" style="margin-top: 0.25rem;">
-                            <div><span id="remainingHours">--</span> hrs</div>
+                            <div><span id="remainingHours">--</span></div>
                             <div><span id="remainingKwh">--</span> kWh</div>
                         </div>
                         <div id="extBatteries" class="ext-battery-info"></div>


### PR DESCRIPTION
## Summary
- Reported by a user (Jérôme) on GitHub: in solar charging mode the dashboard shows the time-to-full in minutes, but labels the value "hrs".
- Root cause: `index.html:1465` statically appended ` hrs` after `#remainingHours`, while the JS at `index.html:2566` already embeds the unit in the value (`⚡ 45m` charging, `🔋 2h 30m` discharging). Rendered output became e.g. `⚡ 45m hrs`.
- Fix: drop the static suffix — the value carries its own unit. Also cleans up the redundant trailing "hrs" in the discharging display.

## Test plan
- [ ] Open the dashboard while solar (or AC) charging — confirm the time reads e.g. `⚡ 45m` with no trailing "hrs".
- [ ] Discharging — confirm the time reads e.g. `🔋 2h 30m` with no trailing "hrs".
- [ ] When time is unavailable, confirm fallback shows `⚡ --` / `🔋 --` cleanly.

https://claude.ai/code/session_01XyEcYtLeuHZwDxeSJF4LnY

---
_Generated by [Claude Code](https://claude.ai/code/session_01XyEcYtLeuHZwDxeSJF4LnY)_