### PR TITLE
Add layout presets and block dangerous register 68 writes

### DIFF
--- a/PROTOCOL.md
+++ b/PROTOCOL.md
@@ -166,12 +166,14 @@ The device uses different function codes (OpCodes) for different types of data:
 | 64  | Power Off | 1 | Command to shutdown device. |
 | 66  | **Discharge Limit** | 0.1% | Min SoC %. Stop discharging at this %. e.g. 100 = 10%. |
 | 67  | **Charge Limit** | 0.1% | Max SoC %. Stop charging at this %. e.g. 1000 = 100%. |
-| 68  | Machine Shutdown | Minutes | Auto-shutdown whole device if idle. No "Never" option; minimum 5 min. |
+| 68  | Machine Shutdown | Minutes | Auto-shutdown whole device if idle. **DO NOT WRITE 0** — confirmed to permanently brick devices in the field (issue #1, 2026-05-02) and per [`schauveau/sydpower-mqtt`](https://github.com/schauveau/sydpower-mqtt) `MQTT-MODBUS.md`. Allowed: 5, 10, 30, 60, 480. |
 | 80  | CRC Checksum | Hex | Packet checksum. |
 
 ### Writable Register Safety Whitelist
 
 **WARNING: Fossibot firmware does NOT validate register write values. Writing an out-of-range value can permanently brick a device.**
+
+> **CONFIRMED BRICK — Reg 68 = 0:** Writing `0` to register 68 (Machine Shutdown / Whole Machine Unused Time) has been confirmed to permanently brick Fossibot devices in the field. A user (issue #1, 2026-05-02) lost a Fossibot F2400W this way; the unit could not be recovered with the standard DC+Light+USB factory-reset chord. The community-maintained [`schauveau/sydpower-mqtt`](https://github.com/schauveau/sydpower-mqtt) project documents the same risk. Forks must keep this register out of any user-writable code path with a value of 0.
 
 | Register | Allowed Values |
 |:---------|:---------------|
@@ -188,7 +190,7 @@ The device uses different function codes (OpCodes) for different types of data:
 | 63 (Stop Charge After) | 0-1440 (minutes) |
 | 66 (Discharge Limit) | 0-1000 (0.1% units) |
 | 67 (Charging Limit) | 0-1000 (0.1% units) |
-| 68 (Sleep Time) | 5, 10, 30, 480 |
+| 68 (Machine Shutdown) | 5, 10, 30, 60, 480 — **NEVER 0 (bricks device)** |
 
 ---
 

--- a/PROTOCOL.md
+++ b/PROTOCOL.md
@@ -166,7 +166,7 @@ The device uses different function codes (OpCodes) for different types of data:
 | 64  | Power Off | 1 | Command to shutdown device. |
 | 66  | **Discharge Limit** | 0.1% | Min SoC %. Stop discharging at this %. e.g. 100 = 10%. |
 | 67  | **Charge Limit** | 0.1% | Max SoC %. Stop charging at this %. e.g. 1000 = 100%. |
-| 68  | Machine Shutdown | Minutes | Auto-shutdown if idle. |
+| 68  | Machine Shutdown | Minutes | Auto-shutdown whole device if idle. No "Never" option; minimum 5 min. |
 | 80  | CRC Checksum | Hex | Packet checksum. |
 
 ### Writable Register Safety Whitelist

--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ ABOK Power Ark3600 (Probalby works, but not tested)
 *   **EPS / UPS Settings:** Configure Entry Power Supply (UPS mode) behavior and upper charge limits.
 *   **Standby Timers:** detailed control over auto-shutdown timers to save power:
     *   **Screen Timeout:** 1 min, 5 min, Never.
-    *   **System Idle Shutdown (Whole Device):** Auto-shutdown the entire device after inactivity (5 min – 8 hr). "Never" is not supported.
+    *   **System Idle Shutdown (Whole Device):** Auto-shutdown the entire device after inactivity (5 min – 8 hr). ⚠️ **"Never" / 0 is not supported and has been confirmed to permanently brick devices** — the option is removed and writes of 0 to register 68 are blocked at the protocol layer.
     *   **AC Standby:** Turn off inverter if no load detected.
     *   **DC/USB Standby:** Turn off low-voltage ports if idle.
 

--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ ABOK Power Ark3600 (Probalby works, but not tested)
 *   **EPS / UPS Settings:** Configure Entry Power Supply (UPS mode) behavior and upper charge limits.
 *   **Standby Timers:** detailed control over auto-shutdown timers to save power:
     *   **Screen Timeout:** 1 min, 5 min, Never.
-    *   **System Standby:** Auto-shutdown after inactivity.
+    *   **System Idle Shutdown (Whole Device):** Auto-shutdown the entire device after inactivity (5 min – 8 hr). "Never" is not supported.
     *   **AC Standby:** Turn off inverter if no load detected.
     *   **DC/USB Standby:** Turn off low-voltage ports if idle.
 

--- a/index.html
+++ b/index.html
@@ -645,6 +645,27 @@
             margin-left: 1px;
         }
 
+        /* Layout presets — hide widgets per layout. Default shows everything. */
+        [data-layout="compact"] [data-widget="battery-ring"],
+        [data-layout="compact"] [data-widget="ext-batteries"],
+        [data-layout="numeric"] [data-widget="battery-ring"],
+        [data-layout="numeric"] [data-widget="ext-batteries"],
+        [data-layout="numeric"] [data-widget="remaining-time"] {
+            display: none;
+        }
+        [data-layout="compact"] .battery-ring-container,
+        [data-layout="numeric"] .battery-ring-container {
+            width: auto;
+            height: auto;
+            margin: 0.25rem auto;
+        }
+        [data-layout="compact"] .battery-text,
+        [data-layout="numeric"] .battery-text {
+            position: static;
+            transform: none;
+            justify-content: center;
+        }
+
         [data-theme="terminal"] .dash-label {
             color: #008800;
         }
@@ -1449,7 +1470,7 @@
                     <div class="dash-col center">
                         <div class="dash-sub" style="margin-bottom: 0.25rem;">Sys: <span id="sysWatts">--</span></div>
                         <div class="battery-ring-container">
-                            <svg width="100%" height="100%" viewBox="0 0 36 36" style="transform: rotate(-90deg);">
+                            <svg data-widget="battery-ring" width="100%" height="100%" viewBox="0 0 36 36" style="transform: rotate(-90deg);">
                                 <path class="ring-bg"
                                     d="M18 2.0845 a 15.9155 15.9155 0 0 1 0 31.831 a 15.9155 15.9155 0 0 1 0 -31.831"
                                     fill="none" stroke="currentColor" stroke-width="3" />
@@ -1461,11 +1482,11 @@
                                     class="battery-unit">%</span>
                             </div>
                         </div>
-                        <div class="dash-sub" style="margin-top: 0.25rem;">
+                        <div class="dash-sub" data-widget="remaining-time" style="margin-top: 0.25rem;">
                             <div><span id="remainingHours">--</span></div>
                             <div><span id="remainingKwh">--</span> kWh</div>
                         </div>
-                        <div id="extBatteries" class="ext-battery-info"></div>
+                        <div id="extBatteries" data-widget="ext-batteries" class="ext-battery-info"></div>
                     </div>
 
                     <div class="dash-col right">
@@ -1727,7 +1748,7 @@
                             <span>mins</span>
                         </div>
                     </div>
-                    <div class="setting-row">
+                    <div class="setting-row" title="WARNING: writing 0 / Never to this register (Reg 68) has been reported to permanently brick Fossibot devices. The Never option has been removed.">
                         <div class="setting-info">
                             <span class="setting-title">System Idle Shutdown</span>
                             <span class="setting-desc">Whole Device <span id="status-sys-standby"
@@ -1791,11 +1812,18 @@
                 <div class="accordion-header" onclick="toggleAccordion('acc-theme')">
                     <div class="accordion-title">
                         <span class="accordion-icon">🎨</span>
-                        Theme
+                        Theme &amp; Layout
                     </div>
                     <span class="accordion-arrow">▼</span>
                 </div>
                 <div class="accordion-content">
+                    <div class="setting-desc" style="margin-bottom:0.25rem;">Dashboard layout</div>
+                    <div class="theme-pills" id="layout-pills" style="margin-bottom:0.75rem;">
+                        <span class="theme-pill active" data-layout="default" onclick="selectLayoutPill('default')">📊 Default</span>
+                        <span class="theme-pill" data-layout="compact" onclick="selectLayoutPill('compact')">📱 Compact</span>
+                        <span class="theme-pill" data-layout="numeric" onclick="selectLayoutPill('numeric')">🔢 Numeric</span>
+                    </div>
+                    <div class="setting-desc" style="margin-bottom:0.25rem;">Theme</div>
                     <div class="theme-pills" id="theme-pills">
                         <span class="theme-pill" data-theme="pipboy" onclick="selectThemePill('pipboy')">☢️
                             Pipboy</span>
@@ -2043,10 +2071,22 @@ Example format:
 
         // Theme pill selection function
         function selectThemePill(themeName) {
-            document.querySelectorAll('.theme-pill').forEach(p => p.classList.remove('active'));
+            document.querySelectorAll('.theme-pill[data-theme]').forEach(p => p.classList.remove('active'));
             const pill = document.querySelector(`.theme-pill[data-theme="${themeName}"]`);
             if (pill) pill.classList.add('active');
             setTheme(themeName);
+        }
+
+        // Layout preset functions
+        function setLayout(layoutName) {
+            document.documentElement.setAttribute('data-layout', layoutName);
+            localStorage.setItem('POWER-layout', layoutName);
+        }
+        function selectLayoutPill(layoutName) {
+            document.querySelectorAll('.theme-pill[data-layout]').forEach(p => p.classList.remove('active'));
+            const pill = document.querySelector(`.theme-pill[data-layout="${layoutName}"]`);
+            if (pill) pill.classList.add('active');
+            setLayout(layoutName);
         }
 
         // Settings
@@ -2076,6 +2116,10 @@ Example format:
             // Default to Ocean
             setTheme('ocean');
         }
+
+        // Initialize Layout
+        const savedLayout = localStorage.getItem('POWER-layout') || 'default';
+        selectLayoutPill(savedLayout);
 
         // Debug Mode
         let isDebug = false;
@@ -4544,6 +4588,12 @@ Example format:
         }, 1000);
 
         function setRegister(reg, val) {
+            if (reg === 68 && Number(val) === 0) {
+                log('BLOCKED: Reg 68 = 0 has been reported to permanently brick devices. Write refused.');
+                console.error('Refusing to write 0 to Reg 68 (whole-device shutdown timer) — known brick risk.');
+                alert('Blocked: writing 0 to register 68 has been reported to permanently brick Fossibot devices. The write was refused.');
+                return;
+            }
             addToQueue(async () => {
                 const cmd = generateCommandBytes(0x11, reg, val); // Address 0x11
                 if (device && writeChar) {

--- a/index.html
+++ b/index.html
@@ -1738,9 +1738,7 @@
                             <option value="10">10 min</option>
                             <option value="30">30 min</option>
                             <option value="60">1 hr</option>
-                            <option value="480">480 min (8h)</option>
-                            <option value="1440">24 hr</option>
-                            <option value="0">Never</option>
+                            <option value="480">8 hr</option>
                         </select>
                     </div>
                     <div class="setting-row">
@@ -2158,9 +2156,7 @@ Example format:
             const machineShutdown = settingsRegisters[68] || 0;
             const sysStandbyStatus = document.getElementById('status-sys-standby');
             if (sysStandbyStatus) {
-                if (machineShutdown === 0) {
-                    sysStandbyStatus.textContent = 'Never';
-                } else if (machineShutdown < 60) {
+                if (machineShutdown < 60) {
                     sysStandbyStatus.textContent = machineShutdown + ' min';
                 } else {
                     sysStandbyStatus.textContent = Math.round(machineShutdown / 60) + 'h';

--- a/service-worker.js
+++ b/service-worker.js
@@ -1,4 +1,4 @@
-const CACHE_NAME = 'fossibot-v49';
+const CACHE_NAME = 'fossibot-v50';
 const ASSETS = [
     './',
     './index.html',


### PR DESCRIPTION
## Summary
This PR adds dashboard layout presets (Default, Compact, Numeric) and implements critical safety protections against a confirmed device-bricking issue with register 68 (Machine Shutdown timer).

## Key Changes

**Layout Presets:**
- Added three dashboard layout options accessible from Theme & Layout settings
- Compact layout hides battery ring and external batteries widgets
- Numeric layout hides battery ring, external batteries, and remaining time widgets
- Layout preference persists via localStorage
- CSS styling adjusts widget visibility and positioning per layout

**Register 68 Safety (Critical):**
- Blocked all writes of value `0` to register 68 at the protocol layer with user-facing alert
- Removed "Never" and "24 hr" options from System Idle Shutdown dropdown
- Updated allowed values to: 5, 10, 30, 60, 480 minutes (8 hr max)
- Added warning tooltip on settings row explaining the brick risk
- Updated documentation (PROTOCOL.md, README.md) with confirmed brick details and safety whitelist

**UI/UX Improvements:**
- Renamed "Theme" accordion section to "Theme & Layout"
- Added layout pill selector UI matching existing theme pill pattern
- Updated status display logic to remove "Never" handling for register 68
- Added data-widget attributes to SVG and divs for CSS-based visibility control

**Documentation:**
- PROTOCOL.md: Added confirmed brick warning for register 68 with issue reference
- README.md: Clarified System Idle Shutdown behavior and brick risk
- Added safety whitelist section documenting the register 68 restriction

**Maintenance:**
- Bumped service worker cache version from v49 to v50

https://claude.ai/code/session_01YAStTqACYZ3q3Q7JB7FZt5