### PR TITLE
Fix false system errors: only treat Reg 8 codes 78/79 as faults

### DIFF
--- a/PROTOCOL.md
+++ b/PROTOCOL.md
@@ -286,6 +286,7 @@ Legacy code/findings suggesting `Lo-Hi` were incorrect and caused packet rejecti
 | 0    | **Normal** | No error. |
 | 78   | **Inverter Fault** | AC inverter offline. DC Charging via Solar still works. |
 | 79   | **AC Charging Interrupted** | Safety Lockout. Triggers for BOTH critical hardware failures AND environmental protection (Cold/Hot). |
+| Other | **Normal (unknown meaning)** | Some firmware reports other non-zero values during normal operation (e.g. 136 / 0x88 observed on a healthy device with Reg 42 = 0xE3D8). Do **not** treat `Reg 8 > 0` as an error — only codes 78 and 79 are confirmed faults. |
 
 ### Fault Detection (Reg 42)
 
@@ -313,7 +314,7 @@ When Reg 8 reports Error 79:
 - **IF `(Reg42 & 0x6000) > 0`:** Hardware Failure (critical).
 - **IF `(Reg42 & 0x6000) == 0`:** Environmental Protection (Cold/Hot Temperature).
 
-If Reg 8 = 0 (Normal), do **not** show any fault — even if bits 13-14 are set in Reg 42.
+If Reg 8 is anything other than 78 or 79 (Normal), do **not** show any fault — even if bits 13-14 are set in Reg 42.
 
 ### UI Display Rules
 

--- a/index.html
+++ b/index.html
@@ -2701,15 +2701,17 @@ Example format:
 
                     // System Status: Error > Charging > Standby
                     // Reg 48 flags: 0x8000=Charging, 0x4000=Standby, 0x0008=Error Pending (transient)
-                    // Reg 8: 0=Normal, 78=Inverter Fault, 79=Safety Lockout
+                    // Reg 8: 78=Inverter Fault, 79=Safety Lockout. Other non-zero values
+                    // (e.g. 136) appear on healthy devices and must NOT be treated as errors.
                     // NOTE: Reg 48 bit 0x0008 is set transiently during AC inverter state changes
                     // and is not a reliable error indicator. Use Reg 8 (errorCode) as authoritative source.
+                    const isKnownError = (errorCode === 78 || errorCode === 79);
                     let sysStatus = '';
-                    if (errorCode > 0) {
+                    if (isKnownError) {
                         const isCritHW = (protFlags & 0x6000) > 0;
                         if (errorCode === 79 && !isCritHW) sysStatus = 'Temp Protection';
-                        else if (errorCode === 78) sysStatus = 'Inverter Fault';
-                        else sysStatus = `Error ${errorCode}`;
+                        else if (errorCode === 79) sysStatus = `Error ${errorCode}`;
+                        else sysStatus = 'Inverter Fault';
                     }
                     else if (statusFlags & 0x8000) sysStatus = 'Charging';
                     else if (statusFlags & 0x4000) sysStatus = 'Standby';
@@ -2730,7 +2732,7 @@ Example format:
                     if (!isDebug) {
                         const effectiveInput = (inputTotal > 0) ? inputTotal : (inputRatified + inputDC);
                         recordHistory(battery, effectiveInput, output);
-                        checkAlerts(battery, isCharging, errorCode, sysStatus);
+                        checkAlerts(battery, isCharging, isKnownError ? errorCode : 0, sysStatus);
                     }
 
                     const displayMinutes = isCharging ? timeToFull : timeToEmpty;
@@ -3587,7 +3589,7 @@ Example format:
             5: { name: 'Unknown (0)', unit: '' },
             6: { name: 'Total Input', unit: 'W' },
             7: { name: 'Error/Warning Code?', format: 'flags' },     // 0 during cold temp warning, needs more data
-            8: { name: 'Active Error Code', format: 'raw' },         // 0=Normal, 78=Inverter Fault, 79=Safety Lockout (Cold/Hot/HW)
+            8: { name: 'Active Error Code', format: 'raw' },         // 78=Inverter Fault, 79=Safety Lockout (Cold/Hot/HW). Other values (0, 136, ...) seen on healthy devices = Normal
             13: { name: 'AC Charge Rate', format: 'charge_level' },
             14: { name: 'Max AC Input', format: 'watt' },         // Confirmed 1100
             16: { name: 'Frequency Set', format: 'freq01' },


### PR DESCRIPTION
## Problem
The dashboard frequently showed `Error N` status and fired 🚨 Device Fault notifications even when the device was healthy.

## Root cause
User diagnostic data showed Reg 8 = **136** on a healthy device (Reg 42 = 0xE3D8, the documented healthy value). The code assumed `Reg 8 > 0` always means a fault, but some firmware reports other non-zero values during normal operation.

## Fix
- Treat only the confirmed fault codes **78** (Inverter Fault) and **79** (Safety Lockout) as errors for both status display and notifications; other values fall through to Charging/Standby status.
- Updated the register documentation in `index.html` and `PROTOCOL.md` to record this finding.

https://claude.ai/code/session_01JGM9LSZGnzBXG4ndBVV58f

---
_Generated by [Claude Code](https://claude.ai/code/session_01JGM9LSZGnzBXG4ndBVV58f)_